### PR TITLE
Fixed percent-encoding on query strings with '+'

### DIFF
--- a/Text/URI/Parser/ByteString.hs
+++ b/Text/URI/Parser/ByteString.hs
@@ -226,11 +226,12 @@ pchar' :: MonadParsec e ByteString m => m Word8
 pchar' = choice
   [ unreservedChar
   , percentEncChar
+  , char 43 >> pure 32
   , oneOf s <?> "sub-delimiter"
   , char 58
   , char 64 ]
   where
-    s = E.fromList (fromIntegral . ord <$> "!$'()*+,;")
+    s = E.fromList (fromIntegral . ord <$> "!$'()*,;")
 {-# INLINE pchar' #-}
 
 isAsciiAlpha :: Word8 -> Bool

--- a/Text/URI/Parser/Text/Utils.hs
+++ b/Text/URI/Parser/Text/Utils.hs
@@ -151,11 +151,12 @@ pchar' :: MonadParsec e Text m => m Char
 pchar' = choice
   [ unreservedChar
   , percentEncChar
+  , char '+' >> pure ' '
   , oneOf s <?> "sub-delimiter"
   , char ':'
   , char '@' ]
   where
-    s = E.fromList "!$'()*+,;"
+    s = E.fromList "!$'()*,;"
 {-# INLINE pchar' #-}
 
 isAsciiAlpha :: Char -> Bool

--- a/Text/URI/Render.hs
+++ b/Text/URI/Render.hs
@@ -268,6 +268,7 @@ isDelim' :: Word8 -> Bool
 isDelim' x
   | x == 33            = True
   | x == 36            = True
-  | x >= 39 && x <= 44 = True
+  | x >= 39 && x <= 42 = True
+  | x == 44            = True
   | x == 59            = True
   | otherwise          = False


### PR DESCRIPTION
Special handling of + is needed in query strings — in rendering, '+' must be percent-encoded, and any '+' encountered in parsing must be parsed as ' '.

Ideally ' ' would be rendered as '+' as well, but this would need changes in several places, and '%20' isn't wrong, so I haven't attempted to implement that.