### PR TITLE
#16 make sure `mkURI` can parse a superfluous & in a query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Modern URI 0.3.0.1
+
+* Allow superfluous `&` right after question sign in query parameters.
+
 ## Modern URI 0.3.0.0
 
 * Uses Megaparsec 7. Visible API changes amount to an adjustment in

--- a/Text/URI/Parser/ByteString.hs
+++ b/Text/URI/Parser/ByteString.hs
@@ -175,6 +175,7 @@ pPath hasAuth = do
 pQuery :: MonadParsec e ByteString m => m [QueryParam]
 pQuery = do
   void (char 63)
+  void (optional (char 38))
   fmap catMaybes . flip sepBy (char 38) . label "query parameter" $ do
     let p = many (pchar' <|> char 47 <|> char 63)
     k' <- p

--- a/Text/URI/Parser/Text.hs
+++ b/Text/URI/Parser/Text.hs
@@ -125,6 +125,7 @@ pPath hasAuth = do
 pQuery :: MonadParsec e Text m => m [QueryParam]
 pQuery = do
   void (char '?')
+  void (optional (char '&'))
   fmap catMaybes . flip sepBy (char '&') . label "query parameter" $ do
     let p = many (pchar' <|> char '/' <|> char '?')
     k' <- p

--- a/tests/Text/URISpec.hs
+++ b/tests/Text/URISpec.hs
@@ -216,6 +216,11 @@ spec = do
         , uriQuery = []
         , uriFragment = Nothing
         }
+    it "parses URIs with superfluous '&' before query parameters" $ do
+      uri <- mkTestURI
+      let s = "https://mark%3a%40:secret:%40@github.com:443/mrkkrp/modern-uri+%3a@?&foo:@=bar+:@#fragment:@"
+      parse urip "" s `shouldParse` uri
+
   describe "render" $ do
     it "sort of works" $
       fmap URI.render mkTestURI `shouldReturn` testURI


### PR DESCRIPTION
Close #16.

like `http://localhost/query/?&key=value`.

Thanks for creating this library in the first place, we used it everywhere we needed URIs!