### PR TITLE
Add mkURIBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Modern URI 0.3.3.0
+
+* Added `mkURIBs` for parsing `ByteString` as a `URI`.
+
 ## Modern URI 0.3.2.0
 
 * Quasi-quoters from `Text.URI.QQ` now can be used in pattern context when

--- a/Text/URI.hs
+++ b/Text/URI.hs
@@ -28,6 +28,7 @@ module Text.URI
   ( -- * Data types
     URI (..),
     mkURI,
+    mkURIBs,
     emptyURI,
     makeAbsolute,
     isPathAbsolute,
@@ -36,6 +37,7 @@ module Text.URI
     UserInfo (..),
     QueryParam (..),
     ParseException (..),
+    ParseExceptionBs (..),
 
     -- * Refined text
     -- $rtext

--- a/Text/URI/Parser/ByteString.hs
+++ b/Text/URI/Parser/ByteString.hs
@@ -15,7 +15,8 @@
 --
 -- URI parser for string 'ByteString', an internal module.
 module Text.URI.Parser.ByteString
-  ( parserBs,
+  ( mkURIBs,
+    parserBs,
   )
 where
 
@@ -38,6 +39,21 @@ import Text.Megaparsec
 import Text.Megaparsec.Byte
 import qualified Text.Megaparsec.Byte.Lexer as L
 import Text.URI.Types hiding (pHost)
+
+-- | Construct a 'URI' from 'ByteString'. The input you pass to 'mkURIBs'
+-- must be a valid URI as per RFC 3986, that is, its components should be
+-- percent-encoded where necessary. In case of parse failure
+-- 'ParseExceptionBs' is thrown.
+--
+-- This function uses the 'parserBs' parser under the hood, which you can also
+-- use directly in a Megaparsec parser.
+--
+-- @since 0.3.3.0
+mkURIBs :: MonadThrow m => ByteString -> m URI
+mkURIBs input =
+  case runParser (parserBs <* eof :: Parsec Void ByteString URI) "" input of
+    Left b -> throwM (ParseExceptionBs b)
+    Right x -> return x
 
 -- | This parser can be used to parse 'URI' from strict 'ByteString'.
 -- Remember to use a concrete non-polymorphic parser type for efficiency.

--- a/Text/URI/Types.hs
+++ b/Text/URI/Types.hs
@@ -30,6 +30,7 @@ module Text.URI.Types
     UserInfo (..),
     QueryParam (..),
     ParseException (..),
+    ParseExceptionBs (..),
 
     -- * Refined text
     RText,
@@ -53,6 +54,7 @@ where
 import Control.DeepSeq
 import Control.Monad
 import Control.Monad.Catch (Exception (..), MonadThrow (..))
+import Data.ByteString (ByteString)
 import Data.Char
 import Data.Data (Data)
 import Data.List (intercalate)
@@ -233,6 +235,20 @@ instance Exception ParseException where
   displayException (ParseException b) = errorBundlePretty b
 
 instance NFData ParseException
+
+-- | Parse exception thrown by 'mkURIBs' when a given 'ByteString' value cannot be
+-- parsed as a 'URI'.
+--
+-- @since 0.3.3.0
+newtype ParseExceptionBs
+  = -- | Arguments are: original input and parse error
+    ParseExceptionBs (ParseErrorBundle ByteString Void)
+  deriving (Show, Eq, Data, Typeable, Generic)
+
+instance Exception ParseExceptionBs where
+  displayException (ParseExceptionBs b) = errorBundlePretty b
+
+instance NFData ParseExceptionBs
 
 ----------------------------------------------------------------------------
 -- Refined text

--- a/tests/Text/URISpec.hs
+++ b/tests/Text/URISpec.hs
@@ -52,6 +52,10 @@ spec = do
               }
           s = "что-то"
       URI.mkURI s `shouldThrow` (== URI.ParseException b)
+  describe "mkURIBs" $ do
+    it "accepts valid URIs" $ do
+      uri <- mkTestURI
+      URI.mkURIBs testURI `shouldReturn` uri
   describe "emptyURI" $ do
     it "parsing of empty input produces emptyURI" $
       URI.mkURI "" `shouldReturn` URI.emptyURI


### PR DESCRIPTION
It felt like this was missing: there was `parser` and `parserBs`, `render` and `renderBs`, but only `mkURI` without a `ByteString` equivalent.

In doing this I also found that we needed a `ByteString` equivalent of `ParseException`. I've added a simple copy of this named `ParseExceptionBs`, as this seemed to be the style followed elsewhere.

I took the liberty of adding to the changelog and bumping the version number in the .cabal. Let me know if I should take this out of the PR.