### PR TITLE
Allow text-2.0

### DIFF
--- a/modern-uri.cabal
+++ b/modern-uri.cabal
@@ -53,7 +53,7 @@ library
         reflection >=2.0 && <3.0,
         tagged >=0.8 && <0.9,
         template-haskell >=2.10 && <2.19,
-        text >=0.2 && <1.3
+        text >=0.2 && <2.1
 
     if flag(dev)
         ghc-options: -Wall -Werror
@@ -84,7 +84,7 @@ test-suite tests
         hspec-megaparsec >=2.0 && <3.0,
         megaparsec >=8.0 && <10.0,
         modern-uri,
-        text >=0.2 && <1.3
+        text >=0.2 && <2.1
 
     if flag(dev)
         ghc-options: -Wall -Werror
@@ -103,7 +103,7 @@ benchmark bench-speed
         criterion >=0.6.2.1 && <1.6,
         megaparsec >=8.0 && <10.0,
         modern-uri,
-        text >=0.2 && <1.3
+        text >=0.2 && <2.1
 
     if flag(dev)
         ghc-options: -O2 -Wall -Werror
@@ -122,7 +122,7 @@ benchmark bench-memory
         deepseq >=1.3 && <1.5,
         megaparsec >=8.0 && <10.0,
         modern-uri,
-        text >=0.2 && <1.3,
+        text >=0.2 && <2.1,
         weigh >=0.0.4
 
     if flag(dev)


### PR DESCRIPTION
Tested using

    cabal test --constraint='text>=2' -w ghc-9.2.2
