### PR TITLE
Allow unreserved characters in host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.6.1
+
+* Host now can contain unreserved characters rather than simply alpha
+  numeric ones, which was against RFC 3986. [Issue
+  73](https://github.com/mrkkrp/modern-uri/issues/73).
+
 ## 0.3.6.0
 
 * Now colons are not escaped in paths, unless the `URI` in question is a

--- a/Text/URI/Parser/ByteString.hs
+++ b/Text/URI/Parser/ByteString.hs
@@ -143,7 +143,7 @@ pHost =
       void (char 46)
       skipSome (unreservedChar <|> subDelimChar <|> char 58)
     regName = fmap (intercalate [46]) . flip sepBy1 (char 46) $ do
-      let ch = percentEncChar <|> asciiAlphaNumChar
+      let ch = percentEncChar <|> unreservedChar
       mx <- optional ch
       case mx of
         Nothing -> return []

--- a/Text/URI/Parser/Text/Utils.hs
+++ b/Text/URI/Parser/Text/Utils.hs
@@ -80,8 +80,8 @@ pHost pe =
     regName = fmap (intercalate ".") . flip sepBy1 (char '.') $ do
       let ch =
             if pe
-              then percentEncChar <|> asciiAlphaNumChar
-              else alphaNumChar
+              then percentEncChar <|> unreservedChar
+              else unreservedCharUnicode
       mx <- optional ch
       case mx of
         Nothing -> return ""
@@ -109,6 +109,12 @@ unreservedChar :: (MonadParsec e Text m) => m Char
 unreservedChar = label "unreserved character" . satisfy $ \x ->
   isAsciiAlphaNum x || x == '-' || x == '.' || x == '_' || x == '~'
 {-# INLINE unreservedChar #-}
+
+-- | Parse an unreserved character allowing Unicode.
+unreservedCharUnicode :: (MonadParsec e Text m) => m Char
+unreservedCharUnicode = label "unreserved character" . satisfy $ \x ->
+  isAlphaNum x || x == '-' || x == '.' || x == '_' || x == '~'
+{-# INLINE unreservedCharUnicode #-}
 
 -- | Parse a percent-encoded character.
 percentEncChar :: (MonadParsec e Text m) => m Char

--- a/Text/URI/Types.hs
+++ b/Text/URI/Types.hs
@@ -526,7 +526,7 @@ arbHost =
             ]
       return ("v" ++ [v] ++ "." ++ xs)
     domainLabel = do
-      let g = arbitrary `suchThat` isAlphaNum
+      let g = arbitrary `suchThat` isUnreservedChar
       x <- g
       xs <-
         listOf $
@@ -534,6 +534,11 @@ arbHost =
       x' <- g
       return ([x] ++ xs ++ [x'])
     regName = intercalate "." <$> resize 5 (listOf1 domainLabel)
+
+-- | Return 'True' if the given character is unreserved.
+isUnreservedChar :: Char -> Bool
+isUnreservedChar x =
+  isAlphaNum x || x == '-' || x == '.' || x == '_' || x == '~'
 
 -- | Make generator for refined text given how to lift a possibly empty
 -- arbitrary 'Text' value into a refined type.


### PR DESCRIPTION
Close #73.

Rather than simply allowing only alpha numeric characters, which is against RFC 3986.