### PR TITLE
Further simply the parser for host

### DIFF
--- a/Text/URI/Parser/Text/Utils.hs
+++ b/Text/URI/Parser/Text/Utils.hs
@@ -78,20 +78,10 @@ pHost pe =
       void (char '.')
       skipSome (unreservedChar <|> subDelimChar <|> char ':')
     regName = fmap (intercalate ".") . flip sepBy1 (char '.') $ do
-      let ch =
-            if pe
-              then percentEncChar <|> unreservedChar
-              else unreservedCharUnicode
-      mx <- optional ch
-      case mx of
-        Nothing -> return ""
-        Just x -> do
-          let r =
-                ch
-                  <|> try
-                    (char '-' <* (lookAhead . try) (ch <|> char '-'))
-          xs <- many r
-          return (x : xs)
+      many $
+        if pe
+          then percentEncChar <|> unreservedChar
+          else unreservedCharUnicode
 {-# INLINEABLE pHost #-}
 
 -- | Parse an ASCII alpha character.

--- a/tests/Text/URISpec.hs
+++ b/tests/Text/URISpec.hs
@@ -140,6 +140,8 @@ spec = do
       URI.mkHost "104.155.144.4.sslip.io" `shouldRText` "104.155.144.4.sslip.io"
       URI.mkHost "юникод.рф" `shouldRText` "юникод.рф"
       URI.mkHost "" `shouldRText` ""
+      URI.mkHost "." `shouldRText` "."
+      URI.mkHost "my-host." `shouldRText` "my-host."
       URI.mkHost "auth_service" `shouldRText` "auth_service"
     it "rejects invalid hosts" $ do
       URI.mkHost ")something"
@@ -293,7 +295,6 @@ spec = do
           ( mconcat
               [ utoks "foo%f0bar",
                 etok '%',
-                etok '-',
                 etok '.',
                 elabel "unreserved character",
                 elabel "host that can be decoded as UTF-8"


### PR DESCRIPTION
Previously the parser tried to follow this sentence form the RFC 3986:

> Such a name consists of a sequence of domain labels separated by ".", each
> domain label starting and ending with an alphanumeric character and possibly
> also containing "-" characters.

(See https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2)

However, I understand now that this is simply a clarification for what domains registered with DNS can be. Technically speaking, there are valid host names that are however not valid domains as per DNS.